### PR TITLE
hotfix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,9 +77,11 @@ const argv = yargs
     alias: "g",
     default: false
   })
+  .scriptName("moiboi")
   .help()
   .alias("help", "h")
-  .alias("version", "v").argv;
+  .alias("version", "v")
+  .argv;
 
 const command = argv._[0];
 


### PR DESCRIPTION
added  .scriptName('moiboi') to replace index.js when using help command